### PR TITLE
Changing S3 paths to match paths of github repo

### DIFF
--- a/etl/constants.py
+++ b/etl/constants.py
@@ -7,11 +7,10 @@ DATA_DIR = os.path.join(SOURCE_DIR, DATA_SUBDIR)
 
 # s3 directories
 BUCKET_NAME = os.environ.get("BUCKET_NAME", "moj-analytics-lookup-tables")
-RAW_DIR = os.environ.get("RAW_DIR", "raw")
 GITHUB_REPO = os.environ.get("GITHUB_REPO", "lookup_testing_repo")
 
-if os.path.isfile('release/tag'):
-    with open('release/tag') as f:
+if os.path.isfile("release/tag"):
+    with open("release/tag") as f:
         RELEASE = f.readline()
 else:
     RELEASE = "dev"

--- a/etl/run.py
+++ b/etl/run.py
@@ -1,19 +1,7 @@
-from constants import (
-    BUCKET_NAME,
-    DATA_DIR,
-    RAW_DIR,
-    GITHUB_REPO,
-    RELEASE,
-)
+from constants import BUCKET_NAME, DATA_DIR, GITHUB_REPO, RELEASE
 from lookup_sync import LookupTableSync
 
 if __name__ == "__main__":
-    lookup_table_sync = LookupTableSync(
-        BUCKET_NAME,
-        DATA_DIR,
-        RAW_DIR,
-        GITHUB_REPO,
-        RELEASE
-    )
+    lookup_table_sync = LookupTableSync(BUCKET_NAME, DATA_DIR, GITHUB_REPO, RELEASE)
 
     lookup_table_sync.sync()


### PR DESCRIPTION
Example:
`data/table1/data.csv` in the lookup repo would create the following path in S3:

```
s3://moj-analytics-lookup-tables/<repo_name>/raw/<release>/data/lookup-source/data/table1/data.csv
```

This PR changes that s3 path to mimic the the github root dir after the `<release>` dir. i.e.
```
s3://moj-analytics-lookup-tables/<repo_name>/<release>/data/table1/data.csv
```

